### PR TITLE
fix!: Make usable for git-dive

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,1 @@
-msrv = "1.60.0"  # MSRV
+msrv = "1.61.0"  # MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     - name: No-default features
       run: cargo test --workspace --no-default-features
   msrv:
-    name: "Check MSRV: 1.60.0"
+    name: "Check MSRV: 1.61.0"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -63,7 +63,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.60.0  # MSRV
+        toolchain: 1.61.0  # MSRV
         profile: minimal
         override: true
     - uses: Swatinem/rust-cache@v1
@@ -117,7 +117,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.60.0  # MSRV
+        toolchain: 1.61.0  # MSRV
         profile: minimal
         override: true
         components: clippy

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -61,9 +61,9 @@ jobs:
     strategy:
       matrix:
         rust:
-        - 1.60.0  # MSRV
+        - 1.61.0  # MSRV
         - stable
-    continue-on-error: ${{ matrix.rust != '1.60.0' }}  # MSRV
+    continue-on-error: ${{ matrix.rust != '1.61.0' }}  # MSRV
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,9 +414,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "proc-exit"
-version = "1.0.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da6bbc8ef87314d4f596ad9d02db375c3f2d77fba91067a6f6a5754fdc8cb49"
+checksum = "d2d778539881515d37cd91925d169f4a351120c5a1b44fce2b7c462b0d7f4ec6"
 
 [[package]]
 name = "proc-macro-error"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,12 @@
 version = 3
 
 [[package]]
-name = "assert_cmd"
-version = "2.0.4"
+name = "aho-corasick"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
- "bstr 0.2.17",
- "doc-comment",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
+ "memchr",
 ]
 
 [[package]]
@@ -41,17 +36,6 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
-]
-
-[[package]]
-name = "bstr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fca0852af221f458706eb0725c03e4ed6c46af9ac98e6a689d5e634215d594dd"
@@ -60,6 +44,15 @@ dependencies = [
  "once_cell",
  "regex-automata",
  "serde",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
 ]
 
 [[package]]
@@ -151,18 +144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
 name = "dunce"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,10 +156,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
-name = "either"
-version = "1.8.0"
+name = "env_logger"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "eyre"
@@ -212,16 +200,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "git-fixture"
 version = "0.2.7"
 dependencies = [
- "assert_cmd",
- "bstr 1.0.1",
+ "bstr",
  "clap",
  "derive_more",
+ "env_logger",
  "eyre",
+ "git2",
  "humantime",
  "humantime-serde",
+ "log",
  "proc-exit",
  "schemars",
  "serde",
@@ -229,6 +228,19 @@ dependencies = [
  "serde_yaml",
  "snapbox",
  "toml",
+]
+
+[[package]]
+name = "git2"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -269,6 +281,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,25 +317,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
+name = "jobserver"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libc"
@@ -322,10 +338,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.14.0+1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "memchr"
@@ -352,31 +401,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
-name = "predicates"
-version = "2.1.1"
+name = "percent-encoding"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
-dependencies = [
- "difflib",
- "itertools",
- "predicates-core",
-]
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "predicates-core"
-version = "1.0.3"
+name = "pkg-config"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
-dependencies = [
- "predicates-core",
- "termtree",
-]
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "proc-exit"
@@ -436,10 +470,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -630,10 +681,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.2.4"
+name = "tinyvec"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
@@ -645,25 +705,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +106,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "concolor"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015267563b1df20adccdd00cb05257b1dfbea70a04928e9cf88ffb850c1a40af"
+dependencies = [
+ "atty",
+ "bitflags",
+ "concolor-query",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6417fe6fc03a8b533fd2177742eeb39a90c7233eedec7bac96d4d6b69a09449"
+
+[[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +191,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys",
+]
+
+[[package]]
 name = "git-fixture"
 version = "0.2.7"
 dependencies = [
@@ -168,6 +227,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "snapbox",
  "toml",
 ]
 
@@ -226,6 +286,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +332,12 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "once_cell"
@@ -352,10 +427,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rustc_version"
@@ -371,6 +464,15 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schemars"
@@ -458,6 +560,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
+
+[[package]]
+name = "snapbox"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98a96656eecd1621c5830831b48eb6903a9f86aaeb61b9f358a9bd462414ddd"
+dependencies = [
+ "concolor",
+ "content_inspector",
+ "dunce",
+ "filetime",
+ "normalize-line-endings",
+ "similar",
+ "snapbox-macros",
+ "tempfile",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
+name = "snapbox-macros"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "485e65c1203eb37244465e857d15a26d3a85a5410648ccb53b18bd44cb3a7336"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +604,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -520,6 +666,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +708,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,3 +758,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/git-fixture"
 categories = ["command-line-interface", "development-tools"]
 keywords = ["git", "cli"]
 edition = "2021"
-rust-version = "1.60.0"  # MSRV
+rust-version = "1.61.0"  # MSRV
 include = [
   "src/**/*",
   "Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,20 +27,32 @@ pre-release-replacements = [
   {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/gitext-rs/git-fixture/compare/{{tag_name}}...HEAD", exactly=1},
 ]
 
+[features]
+cli = ["dep:clap", "dep:proc-exit", "dep:humantime"]
+serde = ["dep:serde", "dep:humantime", "dep:humantime-serde"]
+schema = ["dep:schemars", "json", "serde"]
+yaml = ["dep:serde_yaml", "serde"]
+json = ["dep:serde_json", "serde"]
+toml = ["dep:toml", "serde"]
+
+[[bin]]
+name = "git-fixture"
+required-features = ["cli", "yaml", "json", "toml", "schema"]
+
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-humantime = "2"
-humantime-serde = "1"
+serde = { version = "1", features = ["derive"], optional = true }
+serde_yaml = { version = "0.8.17", optional = true }
+serde_json = { version = "1.0", optional = true }
+toml = { version = "0.5", optional = true }
+humantime = { version = "2", optional = true }
+humantime-serde = { version = "1", optional = true }
 bstr = { version = "1.0", features = ["serde"] }
 derive_more = "0.99.17"
 eyre = "0.6"
-serde_yaml = "0.8.17"
-serde_json = "1.0"
-schemars = { version = "0.8.11", features = ["preserve_order"] }
-toml = "0.5"
+schemars = { version = "0.8.11", features = ["preserve_order"], optional = true }
 assert_cmd = "2.0"
-clap = { version = "4.0", features = ["derive"] }
-proc-exit = "1.0"
+clap = { version = "4.0", features = ["derive"], optional = true }
+proc-exit = { version = "1.0", optional = true}
 
 [dev-dependencies]
 snapbox = { version = "0.4.0", features = ["path"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ pre-release-replacements = [
 ]
 
 [features]
-cli = ["dep:clap", "dep:proc-exit", "dep:humantime"]
+cli = ["dep:clap", "dep:proc-exit", "dep:humantime", "dep:env_logger"]
 serde = ["dep:serde", "dep:humantime", "dep:humantime-serde"]
 schema = ["dep:schemars", "json", "serde"]
 yaml = ["dep:serde_yaml", "serde"]
@@ -50,9 +50,12 @@ bstr = { version = "1.0", features = ["serde"] }
 derive_more = "0.99.17"
 eyre = "0.6"
 schemars = { version = "0.8.11", features = ["preserve_order"], optional = true }
-assert_cmd = "2.0"
 clap = { version = "4.0", features = ["derive"], optional = true }
-proc-exit = { version = "1.0", optional = true}
+proc-exit = { version = "1.0", optional = true }
+env_logger = { version = "0.9.1", optional = true }
+git2 = { version = "0.15.0", default-features = false, features = ["vendored-libgit2"] }
+log = "0.4.17"
 
 [dev-dependencies]
+env_logger = "0.9.1"
 snapbox = { version = "0.4.0", features = ["path"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ derive_more = "0.99.17"
 eyre = "0.6"
 schemars = { version = "0.8.11", features = ["preserve_order"], optional = true }
 clap = { version = "4.0", features = ["derive"], optional = true }
-proc-exit = { version = "1.0", optional = true }
+proc-exit = { version = "2.0", optional = true }
 env_logger = { version = "0.9.1", optional = true }
 git2 = { version = "0.15.0", default-features = false, features = ["vendored-libgit2"] }
 log = "0.4.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,6 @@ toml = "0.5"
 assert_cmd = "2.0"
 clap = { version = "4.0", features = ["derive"] }
 proc-exit = "1.0"
+
+[dev-dependencies]
+snapbox = { version = "0.4.0", features = ["path"] }

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,253 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TodoList",
+  "type": "object",
+  "properties": {
+    "init": {
+      "default": true,
+      "type": "boolean"
+    },
+    "sleep": {
+      "default": null,
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Duration"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "author": {
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "commands": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Command"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Duration": {
+      "type": "object",
+      "required": [
+        "nanos",
+        "secs"
+      ],
+      "properties": {
+        "secs": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "nanos": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Command": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "head"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "label"
+          ],
+          "properties": {
+            "label": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "reset"
+          ],
+          "properties": {
+            "reset": {
+              "$ref": "#/definitions/Reference"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "tree"
+          ],
+          "properties": {
+            "tree": {
+              "$ref": "#/definitions/Tree"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "merge"
+          ],
+          "properties": {
+            "merge": {
+              "$ref": "#/definitions/Merge"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "branch"
+          ],
+          "properties": {
+            "branch": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "tag"
+          ],
+          "properties": {
+            "tag": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Reference": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "branch"
+          ],
+          "properties": {
+            "branch": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "tag"
+          ],
+          "properties": {
+            "tag": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "label"
+          ],
+          "properties": {
+            "label": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Tree": {
+      "type": "object",
+      "required": [
+        "tracked"
+      ],
+      "properties": {
+        "tracked": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/FileContent"
+          }
+        },
+        "message": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "author": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "FileContent": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "Merge": {
+      "type": "object",
+      "required": [
+        "base"
+      ],
+      "properties": {
+        "base": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Reference"
+          }
+        },
+        "message": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "author": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schema.json
+++ b/schema.json
@@ -139,10 +139,10 @@
     "Tree": {
       "type": "object",
       "required": [
-        "tracked"
+        "files"
       ],
       "properties": {
-        "tracked": {
+        "files": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/FileContent"

--- a/schema.json
+++ b/schema.json
@@ -81,7 +81,7 @@
           ],
           "properties": {
             "reset": {
-              "$ref": "#/definitions/Reference"
+              "type": "string"
             }
           },
           "additionalProperties": false
@@ -129,46 +129,6 @@
           ],
           "properties": {
             "tag": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "Reference": {
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "branch"
-          ],
-          "properties": {
-            "branch": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "tag"
-          ],
-          "properties": {
-            "tag": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "label"
-          ],
-          "properties": {
-            "label": {
               "type": "string"
             }
           },
@@ -229,7 +189,7 @@
         "base": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Reference"
+            "type": "string"
           }
         },
         "message": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ impl TodoList {
                             .ok()
                             .wrap_err_with(|| format!("Failed to remove {}", relpath.display()))?;
                     }
-                    for (relpath, content) in tree.tracked.iter() {
+                    for (relpath, content) in tree.files.iter() {
                         let path = cwd.join(relpath);
                         if let Some(parent) = path.parent() {
                             std::fs::create_dir_all(parent).wrap_err_with(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use assert_cmd::output::OutputOkExt;
 use bstr::ByteSlice;
 use eyre::WrapErr;
 
-impl Dag {
+impl TodoList {
     pub fn load(path: &std::path::Path) -> eyre::Result<Self> {
         let data = std::fs::read_to_string(path)
             .wrap_err_with(|| format!("Could not read {}", path.display()))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,8 @@ impl Dag {
                         .arg("-m")
                         .arg(tree.message.as_deref().unwrap_or("Automated"))
                         .current_dir(cwd);
-                    if let Some(author) = tree.author.as_deref() {
+                    if let Some(author) = tree.author.as_deref().or_else(|| self.author.as_deref())
+                    {
                         p.arg("--author").arg(author);
                     }
                     p.ok()?;
@@ -132,7 +133,8 @@ impl Dag {
                     p.arg("merge")
                         .arg(merge.message.as_deref().unwrap_or("Automated"))
                         .current_dir(cwd);
-                    if let Some(author) = merge.author.as_deref() {
+                    if let Some(author) = merge.author.as_deref().or_else(|| self.author.as_deref())
+                    {
                         p.arg("--author").arg(author);
                     }
                     for base in &merge.base {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,13 +62,13 @@ impl Dag {
 
         let mut head = None;
         let mut labels: std::collections::HashMap<Label, String> = Default::default();
-        for event in self.events.iter() {
+        for event in self.commands.iter() {
             match event {
-                Event::Label(label) => {
+                Command::Label(label) => {
                     let commit = current_oid(cwd)?;
                     labels.insert(label.clone(), commit);
                 }
-                Event::Reset(reference) => {
+                Command::Reset(reference) => {
                     let revspec = match &reference {
                         Reference::Label(label) => labels
                             .get(label.as_str())
@@ -79,7 +79,7 @@ impl Dag {
                     };
                     checkout(cwd, revspec)?;
                 }
-                Event::Tree(tree) => {
+                Command::Tree(tree) => {
                     let output = std::process::Command::new("git")
                         .arg("ls-files")
                         .current_dir(cwd)
@@ -128,7 +128,7 @@ impl Dag {
                         std::thread::sleep(sleep);
                     }
                 }
-                Event::Merge(merge) => {
+                Command::Merge(merge) => {
                     let mut p = std::process::Command::new("git");
                     p.arg("merge")
                         .arg(merge.message.as_deref().unwrap_or("Automated"))
@@ -153,7 +153,7 @@ impl Dag {
                         std::thread::sleep(sleep);
                     }
                 }
-                Event::Branch(branch) => {
+                Command::Branch(branch) => {
                     let _ = std::process::Command::new("git")
                         .arg("branch")
                         .arg("-D")
@@ -167,7 +167,7 @@ impl Dag {
                         .current_dir(cwd)
                         .ok()?;
                 }
-                Event::Tag(tag) => {
+                Command::Tag(tag) => {
                     let _ = std::process::Command::new("git")
                         .arg("tag")
                         .arg("-d")
@@ -181,7 +181,7 @@ impl Dag {
                         .current_dir(cwd)
                         .ok()?;
                 }
-                Event::Head => {
+                Command::Head => {
                     let commit = current_oid(cwd)?;
                     head = Some(commit);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,15 +83,11 @@ impl TodoList {
                     let commit = current_oid(cwd)?;
                     labels.insert(label.clone(), commit);
                 }
-                Command::Reset(reference) => {
-                    let revspec = match &reference {
-                        Reference::Label(label) => labels
-                            .get(label.as_str())
-                            .ok_or_else(|| eyre::eyre!("Reference doesn't exist: {:?}", label))?
-                            .as_str(),
-                        Reference::Tag(tag) => tag.as_str(),
-                        Reference::Branch(branch) => branch.as_str(),
-                    };
+                Command::Reset(label) => {
+                    let revspec = labels
+                        .get(label.as_str())
+                        .ok_or_else(|| eyre::eyre!("Label doesn't exist: {:?}", label))?
+                        .as_str();
                     checkout(cwd, revspec)?;
                 }
                 Command::Tree(tree) => {
@@ -153,14 +149,10 @@ impl TodoList {
                         p.arg("--author").arg(author);
                     }
                     for base in &merge.base {
-                        let revspec = match base {
-                            Reference::Label(label) => labels
-                                .get(label.as_str())
-                                .ok_or_else(|| eyre::eyre!("Reference doesn't exist: {:?}", label))?
-                                .as_str(),
-                            Reference::Tag(tag) => tag.as_str(),
-                            Reference::Branch(branch) => branch.as_str(),
-                        };
+                        let revspec = labels
+                            .get(base.as_str())
+                            .ok_or_else(|| eyre::eyre!("Label doesn't exist: {:?}", base))?
+                            .as_str();
                         p.arg(revspec);
                     }
                     p.ok()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,13 @@ use proc_exit::WithCodeResultExt;
 struct Args {
     #[arg(short, long, group = "mode")]
     input: Option<std::path::PathBuf>,
-    #[arg(short)]
+    #[arg(short, long)]
     output: Option<std::path::PathBuf>,
     /// Sleep between commits
     #[arg(long)]
     sleep: Option<humantime::Duration>,
 
-    #[arg(short, group = "mode")]
+    #[arg(long, group = "mode")]
     schema: Option<std::path::PathBuf>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,8 @@ fn main() {
 }
 
 fn run() -> proc_exit::ExitResult {
+    env_logger::init();
+
     let args = Args::parse();
     let output = args
         .output

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,11 +33,11 @@ fn run() -> proc_exit::ExitResult {
 
     if let Some(input) = args.input.as_deref() {
         std::fs::create_dir_all(&output)?;
-        let mut dag = git_fixture::Dag::load(input).with_code(proc_exit::Code::CONFIG_ERR)?;
+        let mut dag = git_fixture::TodoList::load(input).with_code(proc_exit::Code::CONFIG_ERR)?;
         dag.sleep = dag.sleep.or_else(|| args.sleep.map(|s| s.into()));
         dag.run(&output).with_code(proc_exit::Code::FAILURE)?;
     } else if let Some(schema_path) = args.schema.as_deref() {
-        let schema = schemars::schema_for!(git_fixture::Dag);
+        let schema = schemars::schema_for!(git_fixture::TodoList);
         let schema = serde_json::to_string_pretty(&schema).unwrap();
         if schema_path == std::path::Path::new("-") {
             std::io::stdout().write_all(schema.as_bytes())?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -166,6 +166,12 @@ impl std::borrow::Borrow<str> for Label {
     }
 }
 
+impl std::fmt::Display for Label {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -210,6 +216,12 @@ impl std::borrow::Borrow<str> for Branch {
     }
 }
 
+impl std::fmt::Display for Branch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -251,5 +263,11 @@ impl std::borrow::Borrow<str> for Tag {
     #[inline]
     fn borrow(&self) -> &str {
         self.as_str()
+    }
+}
+
+impl std::fmt::Display for Tag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -64,7 +64,7 @@ impl From<Tree> for Command {
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct Tree {
-    pub tracked: std::collections::HashMap<std::path::PathBuf, FileContent>,
+    pub files: std::collections::HashMap<std::path::PathBuf, FileContent>,
     #[cfg_attr(feature = "serde", serde(default))]
     pub message: Option<String>,
     #[cfg_attr(feature = "serde", serde(default))]

--- a/src/model.rs
+++ b/src/model.rs
@@ -44,7 +44,7 @@ impl Default for TodoList {
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub enum Command {
     Label(Label),
-    Reset(Reference),
+    Reset(Label),
     Tree(Tree),
     Merge(Merge),
     Branch(Branch),
@@ -115,40 +115,11 @@ impl<'d> From<&'d str> for FileContent {
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct Merge {
-    pub base: Vec<Reference>,
+    pub base: Vec<Label>,
     #[cfg_attr(feature = "serde", serde(default))]
     pub message: Option<String>,
     #[cfg_attr(feature = "serde", serde(default))]
     pub author: Option<String>,
-}
-
-#[derive(Clone, Debug, derive_more::IsVariant)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-pub enum Reference {
-    Branch(Branch),
-    Tag(Tag),
-    Label(Label),
-}
-
-impl From<Branch> for Reference {
-    fn from(inner: Branch) -> Self {
-        Self::Branch(inner)
-    }
-}
-
-impl From<Tag> for Reference {
-    fn from(inner: Tag) -> Self {
-        Self::Tag(inner)
-    }
-}
-
-impl From<Label> for Reference {
-    fn from(inner: Label) -> Self {
-        Self::Label(inner)
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,16 +1,24 @@
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
-#[serde(rename_all = "snake_case")]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct TodoList {
-    #[serde(default = "init_default")]
+    #[cfg_attr(feature = "serde", serde(default = "init_default"))]
     pub init: bool,
-    #[serde(default)]
-    #[serde(serialize_with = "humantime_serde::serialize")]
-    #[serde(deserialize_with = "humantime_serde::deserialize")]
+    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(serialize_with = "humantime_serde::serialize")
+    )]
+    #[cfg_attr(
+        feature = "serde",
+        serde(deserialize_with = "humantime_serde::deserialize")
+    )]
     pub sleep: Option<std::time::Duration>,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub author: Option<String>,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub commands: Vec<Command>,
 }
 
@@ -29,11 +37,11 @@ impl Default for TodoList {
     }
 }
 
-#[derive(
-    Clone, Debug, serde::Serialize, serde::Deserialize, derive_more::IsVariant, schemars::JsonSchema,
-)]
-#[serde(rename_all = "snake_case")]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, derive_more::IsVariant)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub enum Command {
     Label(Label),
     Reset(Reference),
@@ -50,23 +58,25 @@ impl From<Tree> for Command {
     }
 }
 
-#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
-#[serde(rename_all = "snake_case")]
-#[serde(deny_unknown_fields)]
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct Tree {
     pub tracked: std::collections::HashMap<std::path::PathBuf, FileContent>,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub message: Option<String>,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub author: Option<String>,
 }
 
-#[derive(
-    Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema, derive_more::IsVariant,
-)]
-#[serde(rename_all = "snake_case")]
-#[serde(untagged)]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, derive_more::IsVariant)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub enum FileContent {
     Binary(Vec<u8>),
     Text(String),
@@ -99,22 +109,24 @@ impl<'d> From<&'d str> for FileContent {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
-#[serde(rename_all = "snake_case")]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct Merge {
     pub base: Vec<Reference>,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub message: Option<String>,
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub author: Option<String>,
 }
 
-#[derive(
-    Clone, Debug, serde::Serialize, serde::Deserialize, derive_more::IsVariant, schemars::JsonSchema,
-)]
-#[serde(rename_all = "snake_case")]
-#[serde(deny_unknown_fields)]
+#[derive(Clone, Debug, derive_more::IsVariant)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub enum Reference {
     Branch(Branch),
     Tag(Tag),
@@ -139,19 +151,10 @@ impl From<Label> for Reference {
     }
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    serde::Serialize,
-    serde::Deserialize,
-    schemars::JsonSchema,
-)]
-#[serde(transparent)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Label(String);
 
 impl Label {
@@ -192,19 +195,10 @@ impl std::borrow::Borrow<str> for Label {
     }
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    serde::Serialize,
-    serde::Deserialize,
-    schemars::JsonSchema,
-)]
-#[serde(transparent)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Branch(String);
 
 impl Branch {
@@ -245,19 +239,10 @@ impl std::borrow::Borrow<str> for Branch {
     }
 }
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    serde::Serialize,
-    serde::Deserialize,
-    schemars::JsonSchema,
-)]
-#[serde(transparent)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Tag(String);
 
 impl Tag {

--- a/src/model.rs
+++ b/src/model.rs
@@ -11,7 +11,7 @@ pub struct Dag {
     #[serde(default)]
     pub author: Option<String>,
     #[serde(default)]
-    pub events: Vec<Event>,
+    pub commands: Vec<Command>,
 }
 
 fn init_default() -> bool {
@@ -24,7 +24,7 @@ impl Default for Dag {
             init: init_default(),
             sleep: None,
             author: None,
-            events: Vec::new(),
+            commands: Vec::new(),
         }
     }
 }
@@ -34,7 +34,7 @@ impl Default for Dag {
 )]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
-pub enum Event {
+pub enum Command {
     Label(Label),
     Reset(Reference),
     Tree(Tree),
@@ -44,7 +44,7 @@ pub enum Event {
     Head,
 }
 
-impl From<Tree> for Event {
+impl From<Tree> for Command {
     fn from(tree: Tree) -> Self {
         Self::Tree(tree)
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -9,6 +9,8 @@ pub struct Dag {
     #[serde(deserialize_with = "humantime_serde::deserialize")]
     pub sleep: Option<std::time::Duration>,
     #[serde(default)]
+    pub author: Option<String>,
+    #[serde(default)]
     pub events: Vec<Event>,
 }
 
@@ -21,6 +23,7 @@ impl Default for Dag {
         Self {
             init: init_default(),
             sleep: None,
+            author: None,
             events: Vec::new(),
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,7 @@
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
-pub struct Dag {
+pub struct TodoList {
     #[serde(default = "init_default")]
     pub init: bool,
     #[serde(default)]
@@ -18,7 +18,7 @@ fn init_default() -> bool {
     true
 }
 
-impl Default for Dag {
+impl Default for TodoList {
     fn default() -> Self {
         Self {
             init: init_default(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -10,8 +10,6 @@ pub struct Dag {
     pub sleep: Option<std::time::Duration>,
     #[serde(default)]
     pub events: Vec<Event>,
-    #[serde(skip)]
-    pub import_root: Option<std::path::PathBuf>,
 }
 
 fn init_default() -> bool {
@@ -24,7 +22,6 @@ impl Default for Dag {
             init: init_default(),
             sleep: None,
             events: Vec::new(),
-            import_root: None,
         }
     }
 }
@@ -35,7 +32,6 @@ impl Default for Dag {
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 pub enum Event {
-    Import(std::path::PathBuf),
     Tree(Tree),
     Children(Vec<Vec<Event>>),
     Head(Reference),

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -1,6 +1,11 @@
 #[track_caller]
 fn assert_success(path: impl AsRef<std::path::Path>) {
-    git_fixture::Dag::load(path.as_ref()).unwrap();
+    let dag = git_fixture::Dag::load(path.as_ref()).unwrap();
+
+    let sandbox = snapbox::path::PathFixture::mutable_temp().unwrap();
+    dag.run(sandbox.path().unwrap()).unwrap();
+
+    sandbox.close().unwrap();
 }
 
 #[test]

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "yaml")]
+
 #[track_caller]
 fn assert_success(name: &str) {
     let path = std::path::PathBuf::from(format!("tests/fixtures/{name}.yml"));

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -1,44 +1,49 @@
 #[track_caller]
-fn assert_success(path: impl AsRef<std::path::Path>) {
-    let dag = git_fixture::Dag::load(path.as_ref()).unwrap();
+fn assert_success(name: &str) {
+    let path = std::path::PathBuf::from(format!("tests/fixtures/{name}.yml"));
 
-    let sandbox = snapbox::path::PathFixture::mutable_temp().unwrap();
-    dag.run(sandbox.path().unwrap()).unwrap();
+    let dag = git_fixture::Dag::load(&path).unwrap();
 
-    sandbox.close().unwrap();
+    let tmpdir = std::path::Path::new(std::env!("CARGO_TARGET_TMPDIR"));
+    let sandbox = tmpdir.join("test").join("case").join(name);
+    if sandbox.exists() {
+        std::fs::remove_dir_all(&sandbox).unwrap();
+    }
+    std::fs::create_dir_all(&sandbox).unwrap();
+    dag.run(&sandbox).unwrap();
 }
 
 #[test]
 fn branches() {
-    assert_success("tests/fixtures/branches.yml");
+    assert_success("branches");
 }
 
 #[test]
 fn conflict() {
-    assert_success("tests/fixtures/conflict.yml");
+    assert_success("conflict");
 }
 
 #[test]
 fn fixup() {
-    assert_success("tests/fixtures/fixup.yml");
+    assert_success("fixup");
 }
 
 #[test]
 fn git_rebase_existing() {
-    assert_success("tests/fixtures/git_rebase_existing.yml");
+    assert_success("git_rebase_existing");
 }
 
 #[test]
 fn git_rebase_new() {
-    assert_success("tests/fixtures/git_rebase_new.yml");
+    assert_success("git_rebase_new");
 }
 
 #[test]
 fn pr_semi_linear_merge() {
-    assert_success("tests/fixtures/pr-semi-linear-merge.yml");
+    assert_success("pr-semi-linear-merge");
 }
 
 #[test]
 fn pr_squash() {
-    assert_success("tests/fixtures/pr-squash.yml");
+    assert_success("pr-squash");
 }

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -2,7 +2,7 @@
 fn assert_success(name: &str) {
     let path = std::path::PathBuf::from(format!("tests/fixtures/{name}.yml"));
 
-    let dag = git_fixture::Dag::load(&path).unwrap();
+    let dag = git_fixture::TodoList::load(&path).unwrap();
 
     let tmpdir = std::path::Path::new(std::env!("CARGO_TARGET_TMPDIR"));
     let sandbox = tmpdir.join("test").join("case").join(name);

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -2,6 +2,8 @@
 
 #[track_caller]
 fn assert_success(name: &str) {
+    let _ = env_logger::try_init();
+
     let path = std::path::PathBuf::from(format!("tests/fixtures/{name}.yml"));
 
     let dag = git_fixture::TodoList::load(&path).unwrap();

--- a/tests/fixtures/branches.yml
+++ b/tests/fixtures/branches.yml
@@ -4,7 +4,7 @@ events:
     tracked:
       "file_a.txt": "1"
     message: "1"
-    branch: initial
+- branch: initial
 - tree:
     tracked:
       "file_a.txt": "2"
@@ -13,44 +13,51 @@ events:
     tracked:
       "file_a.txt": "3"
     message: "3"
-    branch: base
-- children:
-  - - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "1"
-        message: "4"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "2"
-        message: "5"
-        branch: master
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "3"
-        message: "6"
-        branch: off_master
-  - - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_c.txt": "1"
-        message: "7"
-        branch: feature1
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_c.txt": "2"
-        message: "8"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_c.txt": "3"
-        message: "9"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_c.txt": "4"
-        message: "10"
-        branch: feature2
+- branch: base
+- label: base
+
+- reset:
+    label: base
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "1"
+    message: "4"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "2"
+    message: "5"
+- branch: master
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "3"
+    message: "6"
+- branch: off_master
+
+- reset:
+    label: base
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_c.txt": "1"
+    message: "7"
+- branch: feature1
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_c.txt": "2"
+    message: "8"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_c.txt": "3"
+    message: "9"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_c.txt": "4"
+    message: "10"
+- branch: feature2
+- head:

--- a/tests/fixtures/branches.yml
+++ b/tests/fixtures/branches.yml
@@ -16,8 +16,7 @@ commands:
 - branch: base
 - label: base
 
-- reset:
-    label: base
+- reset: base
 - tree:
     tracked:
       "file_a.txt": "3"
@@ -36,8 +35,7 @@ commands:
     message: "6"
 - branch: off_master
 
-- reset:
-    label: base
+- reset: base
 - tree:
     tracked:
       "file_a.txt": "3"

--- a/tests/fixtures/branches.yml
+++ b/tests/fixtures/branches.yml
@@ -1,5 +1,5 @@
 init: true
-events:
+commands:
 - tree:
     tracked:
       "file_a.txt": "1"

--- a/tests/fixtures/branches.yml
+++ b/tests/fixtures/branches.yml
@@ -1,16 +1,16 @@
 init: true
 commands:
 - tree:
-    tracked:
+    files:
       "file_a.txt": "1"
     message: "1"
 - branch: initial
 - tree:
-    tracked:
+    files:
       "file_a.txt": "2"
     message: "2"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
     message: "3"
 - branch: base
@@ -18,18 +18,18 @@ commands:
 
 - reset: base
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "1"
     message: "4"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "2"
     message: "5"
 - branch: master
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "3"
     message: "6"
@@ -37,23 +37,23 @@ commands:
 
 - reset: base
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "1"
     message: "7"
 - branch: feature1
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "2"
     message: "8"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "3"
     message: "9"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "4"
     message: "10"

--- a/tests/fixtures/conflict.yml
+++ b/tests/fixtures/conflict.yml
@@ -1,16 +1,16 @@
 init: true
 commands:
 - tree:
-    tracked:
+    files:
       "file_a.txt": "1"
     message: "1"
 - branch: initial
 - tree:
-    tracked:
+    files:
       "file_a.txt": "2"
     message: "2"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
     message: "3"
 - branch: base
@@ -18,18 +18,18 @@ commands:
 
 - reset: base
 - tree:
-    tracked:
+    files:
       "file_a.txt": "4"
     message: "4"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "5"
     message: "5"
 - branch: master
 
 - reset: base
 - tree:
-    tracked:
+    files:
       "file_a.txt": "6"
     message: "7"
 - branch: feature1

--- a/tests/fixtures/conflict.yml
+++ b/tests/fixtures/conflict.yml
@@ -16,8 +16,7 @@ commands:
 - branch: base
 - label: base
 
-- reset:
-    label: base
+- reset: base
 - tree:
     tracked:
       "file_a.txt": "4"
@@ -28,8 +27,7 @@ commands:
     message: "5"
 - branch: master
 
-- reset:
-    label: base
+- reset: base
 - tree:
     tracked:
       "file_a.txt": "6"

--- a/tests/fixtures/conflict.yml
+++ b/tests/fixtures/conflict.yml
@@ -1,5 +1,5 @@
 init: true
-events:
+commands:
 - tree:
     tracked:
       "file_a.txt": "1"

--- a/tests/fixtures/conflict.yml
+++ b/tests/fixtures/conflict.yml
@@ -4,7 +4,7 @@ events:
     tracked:
       "file_a.txt": "1"
     message: "1"
-    branch: initial
+- branch: initial
 - tree:
     tracked:
       "file_a.txt": "2"
@@ -13,19 +13,25 @@ events:
     tracked:
       "file_a.txt": "3"
     message: "3"
-    branch: base
-- children:
-  - - tree:
-        tracked:
-          "file_a.txt": "4"
-        message: "4"
-    - tree:
-        tracked:
-          "file_a.txt": "5"
-        message: "5"
-        branch: master
-  - - tree:
-        tracked:
-          "file_a.txt": "6"
-        message: "7"
-        branch: feature1
+- branch: base
+- label: base
+
+- reset:
+    label: base
+- tree:
+    tracked:
+      "file_a.txt": "4"
+    message: "4"
+- tree:
+    tracked:
+      "file_a.txt": "5"
+    message: "5"
+- branch: master
+
+- reset:
+    label: base
+- tree:
+    tracked:
+      "file_a.txt": "6"
+    message: "7"
+- branch: feature1

--- a/tests/fixtures/fixup.yml
+++ b/tests/fixtures/fixup.yml
@@ -1,59 +1,59 @@
 init: true
 commands:
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
     message: "commit 1"
 - branch: base
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "1"
     message: "commit 2"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "2"
     message: "master commit"
 - branch: master
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "3"
     message: "feature1 commit 1"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "5"
     message: "feature1 commit 2"
 - branch: feature1
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "1"
     message: "fixup! feature1 commit 1"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "4"
     message: "feature1 commit 3"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "1"
     message: "fixup! feature1 commit 1"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "2"
     message: "fixup! feature1 commit 2"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "4"
     message: "feature2 commit"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "1"
     message: "fixup! feature1 commit 1"

--- a/tests/fixtures/fixup.yml
+++ b/tests/fixtures/fixup.yml
@@ -1,5 +1,5 @@
 init: true
-events:
+commands:
 - tree:
     tracked:
       "file_a.txt": "3"

--- a/tests/fixtures/fixup.yml
+++ b/tests/fixtures/fixup.yml
@@ -4,7 +4,7 @@ events:
     tracked:
       "file_a.txt": "3"
     message: "commit 1"
-    branch: base
+- branch: base
 - tree:
     tracked:
       "file_a.txt": "3"
@@ -15,7 +15,7 @@ events:
       "file_a.txt": "3"
       "file_b.txt": "2"
     message: "master commit"
-    branch: master
+- branch: master
 - tree:
     tracked:
       "file_a.txt": "3"
@@ -26,7 +26,7 @@ events:
       "file_a.txt": "3"
       "file_b.txt": "5"
     message: "feature1 commit 2"
-    branch: feature1
+- branch: feature1
 - tree:
     tracked:
       "file_a.txt": "3"
@@ -57,4 +57,4 @@ events:
       "file_a.txt": "3"
       "file_c.txt": "1"
     message: "fixup! feature1 commit 1"
-    branch: feature2
+- branch: feature2

--- a/tests/fixtures/git_rebase_existing.yml
+++ b/tests/fixtures/git_rebase_existing.yml
@@ -4,7 +4,7 @@ events:
     tracked:
       "file_a.txt": "1"
     message: "1"
-    branch: initial
+- branch: initial
 - tree:
     tracked:
       "file_a.txt": "2"
@@ -13,23 +13,29 @@ events:
     tracked:
       "file_a.txt": "3"
     message: "3"
-    branch: master
-- children:
-  - - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "1"
-        message: "7"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "2"
-        message: "8"
-        branch: feature2
-  # `git rebase master` caused the history to split
-  - - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "1"
-        message: "7"
-        branch: feature1
+- branch: master
+- label: master
+
+- reset:
+    label: master
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "1"
+    message: "7"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "2"
+    message: "8"
+- branch: feature2
+
+# `git rebase master` caused the history to split
+- reset:
+    label: master
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "1"
+    message: "7"
+- branch: feature1

--- a/tests/fixtures/git_rebase_existing.yml
+++ b/tests/fixtures/git_rebase_existing.yml
@@ -16,8 +16,7 @@ commands:
 - branch: master
 - label: master
 
-- reset:
-    label: master
+- reset: master
 - tree:
     tracked:
       "file_a.txt": "3"
@@ -31,8 +30,7 @@ commands:
 - branch: feature2
 
 # `git rebase master` caused the history to split
-- reset:
-    label: master
+- reset: master
 - tree:
     tracked:
       "file_a.txt": "3"

--- a/tests/fixtures/git_rebase_existing.yml
+++ b/tests/fixtures/git_rebase_existing.yml
@@ -1,16 +1,16 @@
 init: true
 commands:
 - tree:
-    tracked:
+    files:
       "file_a.txt": "1"
     message: "1"
 - branch: initial
 - tree:
-    tracked:
+    files:
       "file_a.txt": "2"
     message: "2"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
     message: "3"
 - branch: master
@@ -18,12 +18,12 @@ commands:
 
 - reset: master
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "1"
     message: "7"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "2"
     message: "8"
@@ -32,7 +32,7 @@ commands:
 # `git rebase master` caused the history to split
 - reset: master
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "1"
     message: "7"

--- a/tests/fixtures/git_rebase_existing.yml
+++ b/tests/fixtures/git_rebase_existing.yml
@@ -1,5 +1,5 @@
 init: true
-events:
+commands:
 - tree:
     tracked:
       "file_a.txt": "1"

--- a/tests/fixtures/git_rebase_new.yml
+++ b/tests/fixtures/git_rebase_new.yml
@@ -1,5 +1,5 @@
 init: true
-events:
+commands:
 - tree:
     tracked:
       "file_a.txt": "1"

--- a/tests/fixtures/git_rebase_new.yml
+++ b/tests/fixtures/git_rebase_new.yml
@@ -1,16 +1,16 @@
 init: true
 commands:
 - tree:
-    tracked:
+    files:
       "file_a.txt": "1"
     message: "1"
 - branch: initial
 - tree:
-    tracked:
+    files:
       "file_a.txt": "2"
     message: "2"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
     message: "3"
 - branch: master
@@ -18,12 +18,12 @@ commands:
 
 - reset: master
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "1"
     message: "7"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "1"
       "file_c.txt": "1"
@@ -33,7 +33,7 @@ commands:
 # `git rebase master` caused the history to split
 - reset: master
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "1"
     message: "7"

--- a/tests/fixtures/git_rebase_new.yml
+++ b/tests/fixtures/git_rebase_new.yml
@@ -4,7 +4,7 @@ events:
     tracked:
       "file_a.txt": "1"
     message: "1"
-    branch: initial
+- branch: initial
 - tree:
     tracked:
       "file_a.txt": "2"
@@ -13,24 +13,30 @@ events:
     tracked:
       "file_a.txt": "3"
     message: "3"
-    branch: master
-- children:
-  - - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "1"
-        message: "7"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "1"
-          "file_c.txt": "1"
-        message: "8"
-        branch: feature2
-  # `git rebase master` caused the history to split
-  - - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "1"
-        message: "7"
-        branch: feature1
+- branch: master
+- label: master
+
+- reset:
+    label: master
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "1"
+    message: "7"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "1"
+      "file_c.txt": "1"
+    message: "8"
+- branch: feature2
+
+# `git rebase master` caused the history to split
+- reset:
+    label: master
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "1"
+    message: "7"
+- branch: feature1

--- a/tests/fixtures/git_rebase_new.yml
+++ b/tests/fixtures/git_rebase_new.yml
@@ -16,8 +16,7 @@ commands:
 - branch: master
 - label: master
 
-- reset:
-    label: master
+- reset: master
 - tree:
     tracked:
       "file_a.txt": "3"
@@ -32,8 +31,7 @@ commands:
 - branch: feature2
 
 # `git rebase master` caused the history to split
-- reset:
-    label: master
+- reset: master
 - tree:
     tracked:
       "file_a.txt": "3"

--- a/tests/fixtures/pr-semi-linear-merge.yml
+++ b/tests/fixtures/pr-semi-linear-merge.yml
@@ -1,5 +1,5 @@
 init: true
-events:
+commands:
 - tree:
     tracked:
       "file_a.txt": "1"

--- a/tests/fixtures/pr-semi-linear-merge.yml
+++ b/tests/fixtures/pr-semi-linear-merge.yml
@@ -16,8 +16,7 @@ commands:
 - branch: base
 - label: base
 
-- reset:
-    label: base
+- reset: base
 - tree:
     tracked:
       "file_a.txt": "3"
@@ -61,8 +60,7 @@ commands:
     message: "10"
 - branch: master
 
-- reset:
-    label: base
+- reset: base
 - tree:
     tracked:
       "file_a.txt": "3"

--- a/tests/fixtures/pr-semi-linear-merge.yml
+++ b/tests/fixtures/pr-semi-linear-merge.yml
@@ -4,7 +4,7 @@ events:
     tracked:
       "file_a.txt": "1"
     message: "1"
-    branch: initial
+- branch: initial
 - tree:
     tracked:
       "file_a.txt": "2"
@@ -13,69 +13,75 @@ events:
     tracked:
       "file_a.txt": "3"
     message: "3"
-    branch: base
-- children:
-  - - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "1"
-        message: "4"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "2"
-        message: "5"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "3"
-        message: "6"
-        branch: old_master
-    # AzDO has the "semi-linear merge" type which rebases the branch before merging
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "3"
-          "file_c.txt": "1"
-        message: "7"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "3"
-          "file_c.txt": "2"
-        message: "8"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "3"
-          "file_c.txt": "3"
-        message: "9"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "3"
-          "file_c.txt": "4"
-        message: "10"
-        branch: master
-  - - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_c.txt": "1"
-        message: "7"
-        branch: feature1
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_c.txt": "2"
-        message: "8"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_c.txt": "3"
-        message: "9"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_c.txt": "4"
-        message: "10"
-        branch: feature2
+- branch: base
+- label: base
+
+- reset:
+    label: base
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "1"
+    message: "4"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "2"
+    message: "5"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "3"
+    message: "6"
+- branch: old_master
+# AzDO has the "semi-linear merge" type which rebases the branch before merging
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "3"
+      "file_c.txt": "1"
+    message: "7"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "3"
+      "file_c.txt": "2"
+    message: "8"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "3"
+      "file_c.txt": "3"
+    message: "9"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "3"
+      "file_c.txt": "4"
+    message: "10"
+- branch: master
+
+- reset:
+    label: base
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_c.txt": "1"
+    message: "7"
+- branch: feature1
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_c.txt": "2"
+    message: "8"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_c.txt": "3"
+    message: "9"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_c.txt": "4"
+    message: "10"
+- branch: feature2

--- a/tests/fixtures/pr-semi-linear-merge.yml
+++ b/tests/fixtures/pr-semi-linear-merge.yml
@@ -1,16 +1,16 @@
 init: true
 commands:
 - tree:
-    tracked:
+    files:
       "file_a.txt": "1"
     message: "1"
 - branch: initial
 - tree:
-    tracked:
+    files:
       "file_a.txt": "2"
     message: "2"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
     message: "3"
 - branch: base
@@ -18,42 +18,42 @@ commands:
 
 - reset: base
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "1"
     message: "4"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "2"
     message: "5"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "3"
     message: "6"
 - branch: old_master
 # AzDO has the "semi-linear merge" type which rebases the branch before merging
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "3"
       "file_c.txt": "1"
     message: "7"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "3"
       "file_c.txt": "2"
     message: "8"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "3"
       "file_c.txt": "3"
     message: "9"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "3"
       "file_c.txt": "4"
@@ -62,23 +62,23 @@ commands:
 
 - reset: base
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "1"
     message: "7"
 - branch: feature1
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "2"
     message: "8"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "3"
     message: "9"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "4"
     message: "10"

--- a/tests/fixtures/pr-squash.yml
+++ b/tests/fixtures/pr-squash.yml
@@ -1,16 +1,16 @@
 init: true
 commands:
 - tree:
-    tracked:
+    files:
       "file_a.txt": "1"
     message: "1"
 - branch: initial
 - tree:
-    tracked:
+    files:
       "file_a.txt": "2"
     message: "2"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
     message: "3"
 - branch: base
@@ -18,24 +18,24 @@ commands:
 
 - reset: base
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "1"
     message: "4"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "2"
     message: "5"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "3"
     message: "6"
 - branch: old_master
 # Squashed "feature2" into a single commit and committed it onto master
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_b.txt": "3"
       "file_c.txt": "4"
@@ -44,23 +44,23 @@ commands:
 
 - reset: base
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "1"
     message: "7"
 - branch: feature1
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "2"
     message: "8"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "3"
     message: "9"
 - tree:
-    tracked:
+    files:
       "file_a.txt": "3"
       "file_c.txt": "4"
     message: "10"

--- a/tests/fixtures/pr-squash.yml
+++ b/tests/fixtures/pr-squash.yml
@@ -1,5 +1,5 @@
 init: true
-events:
+commands:
 - tree:
     tracked:
       "file_a.txt": "1"

--- a/tests/fixtures/pr-squash.yml
+++ b/tests/fixtures/pr-squash.yml
@@ -16,8 +16,7 @@ commands:
 - branch: base
 - label: base
 
-- reset:
-    label: base
+- reset: base
 - tree:
     tracked:
       "file_a.txt": "3"
@@ -43,8 +42,7 @@ commands:
     message: "Merged #10"
 - branch: master
 
-- reset:
-    label: base
+- reset: base
 - tree:
     tracked:
       "file_a.txt": "3"

--- a/tests/fixtures/pr-squash.yml
+++ b/tests/fixtures/pr-squash.yml
@@ -4,7 +4,7 @@ events:
     tracked:
       "file_a.txt": "1"
     message: "1"
-    branch: initial
+- branch: initial
 - tree:
     tracked:
       "file_a.txt": "2"
@@ -13,51 +13,57 @@ events:
     tracked:
       "file_a.txt": "3"
     message: "3"
-    branch: base
-- children:
-  - - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "1"
-        message: "4"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "2"
-        message: "5"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "3"
-        message: "6"
-        branch: old_master
-    # Squashed "feature2" into a single commit and committed it onto master
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_b.txt": "3"
-          "file_c.txt": "4"
-        message: "Merged #10"
-        branch: master
-  - - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_c.txt": "1"
-        message: "7"
-        branch: feature1
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_c.txt": "2"
-        message: "8"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_c.txt": "3"
-        message: "9"
-    - tree:
-        tracked:
-          "file_a.txt": "3"
-          "file_c.txt": "4"
-        message: "10"
-        branch: feature2
+- branch: base
+- label: base
+
+- reset:
+    label: base
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "1"
+    message: "4"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "2"
+    message: "5"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "3"
+    message: "6"
+- branch: old_master
+# Squashed "feature2" into a single commit and committed it onto master
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_b.txt": "3"
+      "file_c.txt": "4"
+    message: "Merged #10"
+- branch: master
+
+- reset:
+    label: base
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_c.txt": "1"
+    message: "7"
+- branch: feature1
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_c.txt": "2"
+    message: "8"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_c.txt": "3"
+    message: "9"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+      "file_c.txt": "4"
+    message: "10"
+- branch: feature2

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -1,0 +1,12 @@
+#![cfg(feature = "cli")]
+
+#[test]
+fn dump_schema() {
+    let bin_path = snapbox::cmd::cargo_bin!("git-fixture");
+    snapbox::cmd::Command::new(bin_path)
+        .arg("--schema")
+        .arg("-")
+        .assert()
+        .success()
+        .stdout_eq_path("schema.json");
+}


### PR DESCRIPTION
The old format wasn't great to work with.  This new format is now more reminiscent of `git rebase -i`'s todo list which will hopefully make it easier to work with.

It should also be faster now by using `git2`.